### PR TITLE
feat: add options to bionicify markdown function

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ import remarkStringify from "remark-stringify";
 
 import mdToBionic from "./local-plugins/md-to-bionic.js";
 
-function bionicifyMarkdown(md) {
+function bionicifyMarkdown(md, options) {
   const vFile = unified()
     .use(remarkParse)
     .use(mdToBionic)
@@ -13,10 +13,28 @@ function bionicifyMarkdown(md) {
     .use(remarkFrontmatter)
     .processSync(md);
 
-  const markdownContent = vFile.value
-    .replace(/\\\_/g, "_")
-    .replace(/\\\[/g, "[");
-  return markdownContent;
+  // It was originally defaulting to use underscores, but some parsers have a problem with this.
+  // Adding both underscores and asterisks regex as a workaround.
+  // The default is to use the normal textVide package, which uses underscores.
+  if (options && Object.keys(options).length) {
+    const useUnderscore = options?.useUnderscore ?? false;
+    const useAsterick = options?.useAsterick ?? false;
+
+    if (useUnderscore) {
+      const markdownContent = vFile.value
+        .replace(/\\\_/g, "_")
+        .replace(/\\\[/g, "[");
+      return markdownContent;
+    }
+
+    if (useAsterick) {
+      const markdownContent = vFile.value
+        .replace(/\\\_/g, "*")
+        .replace(/\\\[/g, "[");
+      return markdownContent;
+    }
+  }
+  return vFile.value
 }
 
 export default bionicifyMarkdown;

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,42 @@ console.log(bionicifyMarkdown(md));
 // log: '**Thi**s **i**s **som**e **markdo**wn\n'
 ```
 
+## Options
+Running the package without options will return the default response from the [textVide](https://www.npmjs.com/package/text-vide) package, but this doesn't always play well with markdown parsers. 
+
+You can pass optional flags to run custom regex functions that will switch out the textVide default response with a slightly improved underscore strategy or with an asterick strategy. 
+```js
+import bionicifyMarkdown from "bionic-markdown";
+
+const md = "This is some markdown";
+
+// Optional flags to use either 
+options = {
+  useAsterick: true,
+  useUnderscore: false
+}
+
+const markdown = bionicifyMarkdown(md, options);
+```
+
+This is what these options are doing under the hood:
+```js
+// bionic-markdown/index.js
+if (useUnderscore) {
+  const markdownContent = vFile.value
+    .replace(/\\\_/g, "_")
+    .replace(/\\\[/g, "[");
+  return markdownContent;
+}
+
+if (useAsterick) {
+  const markdownContent = vFile.value
+    .replace(/\\\_/g, "*")
+    .replace(/\\\[/g, "[");
+  return markdownContent;
+}
+```
+
 ## Caveats
 
 The functionality of this package is tailored towards its authors needs. As such, any MAST nodes with text values containing any of the elements below will not be converted:


### PR DESCRIPTION
This change adds options where users can choose to use either astericks or underscores for the bionification of the markdown.

Available options:
`useAsterick`
`useUnderscore`

Default uses the textVide bare response

Example usage: 
```js
function markdownToBionic() {
    return bionicifyMarkdown(this.markdownContent, {useAsterick: true});
}
```